### PR TITLE
fixing global definition of fastlane card array

### DIFF
--- a/fastlane.js
+++ b/fastlane.js
@@ -169,6 +169,8 @@ const pingScrumMasters = (robot, text) => {
 
 module.exports = (robot) =>
   setInterval(() => {
+    endCursor = null
+    fastlaneCards.length = 0
     robot.error(function (err, res) {
       robot.logger.error(err)
       robot.send(


### PR DESCRIPTION
FastlaneCards was initialized globally; therefore, after each interval, the item in it gets appended, hence our bot gives multiple responses. 