### PR TITLE
fix: error logs are reported cumulatively

### DIFF
--- a/fastlane.js
+++ b/fastlane.js
@@ -154,7 +154,7 @@ const pingScrumMasters = (robot, text) => {
       typeof parsedBody.events === "undefined" ||
       parsedBody.events.length === 0
     ) {
-      robot.emit("error", `problem getting scrummaster: '${body}'`)
+      robot.emit("error", `scrummasters not found: '${body}'`)
       return
     }
     const scrummaster = parsedBody.events[0].title
@@ -167,17 +167,16 @@ const pingScrumMasters = (robot, text) => {
   })
 }
 
-module.exports = (robot) =>
-  setInterval(() => {
+module.exports = (robot) => {
+  robot.error(function (err) {
+    robot.logger.error(err)
+    robot.send({ room: room }, `Error while running fastlane bot: ${err}`)
+  })
+
+  return setInterval(() => {
     endCursor = null
     fastlaneCards.length = 0
-    robot.error(function (err, res) {
-      robot.logger.error(err)
-      robot.send(
-        { room: room },
-        `there is an issue with the fastlane bot '${err}'`
-      )
-    })
 
     reportFastlaneCards(robot)
   }, interval)
+}

--- a/scrummasters.js
+++ b/scrummasters.js
@@ -2,9 +2,9 @@ const teamupCalendarKey = 'ks1c2vhnot2ttfvawo'
 const teamupToken = process.env.HUBOT_TEAMUP_TOKEN
 
 module.exports = (robot) => {
-  robot.error(function (err, res) {
+  robot.error(function (err) {
     robot.logger.error(err)
-    res.send(`there is an issue with the fastlane bot '${err}'`)
+    robot.send(`Error while running scrummaster bot: ${err}`)
   })
   robot.hear(/scrum(\s|-)?master(s)?/gi, (res) => {
     const dateString = new Date().toISOString().slice(0, 10)
@@ -23,7 +23,7 @@ module.exports = (robot) => {
           return
         }
         if (typeof parsedBody.events === 'undefined' || parsedBody.events.length === 0) {
-          robot.emit('error', `problem getting scrummaster: '${body}'`, res)
+          robot.emit('error', `scrummasters not found: '${body}'`)
           return
         }
         const scrummaster = parsedBody.events[0].title


### PR DESCRIPTION
Whenever there is error in fastlane script, the error gets added cumulatively which caused the bot to report all the cumulated error messages to the chat.

This PR fixes that issue by moving the error handler out of the setInterval method. Also, renamed some error messages for clarity