### PR TITLE
CI: Add workflow to build and release binary on tag

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,37 @@
+name: Build the binary and create release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache-dependency-path: teamup-rocketchat-bot/go.sum
+
+      - name: Build the binary for linux/amd64
+        working-directory: teamup-rocketchat-bot
+        run: |
+         OUTPUT_NAME=teamup-rocketchat-bot-linux-amd64-${{ github.ref_name }}
+         GOARCH=amd64 GOOS=linux go build -o build/$OUTPUT_NAME .
+         echo "binary created with filename $(ls build/)"
+
+      - name: Create GitHub release and upload binary
+        uses: softprops/action-gh-release@v2
+        with:
+          files: teamup-rocketchat-bot/build/teamup-rocketchat-bot-linux-amd64-${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Add CI to build and release binary
- Adds GitHub Actions workflow to build linux/amd64 binary
- Triggers on tag push or manually via workflow_dispatch
- Uploads built binary to GitHub Releases